### PR TITLE
Adds minSilence as a valid attribute for Wait

### DIFF
--- a/plivoxml.py
+++ b/plivoxml.py
@@ -123,7 +123,7 @@ class Play(Element):
 
 class Wait(Element):
     nestables = ()
-    valid_attributes = ('length', 'silence', 'min_silence')
+    valid_attributes = ('length', 'silence', 'min_silence', 'minSilence')
 
     def __init__(self, **attributes):
         Element.__init__(self, body='', **attributes)


### PR DESCRIPTION
minSilence is standard name of the attribute according to documentation. min_silence works too, though it may be removed later.
