### PR TITLE
Support POST on URI with query strings

### DIFF
--- a/plivo.py
+++ b/plivo.py
@@ -31,22 +31,21 @@ def validate_signature(uri, post_params, signature, auth_token):
     See https://www.plivo.com/docs/xml/request/#validation
 
     :param uri: Your server URL
-    :param post_params: POST Parameters passed to your URL, in case of POST request. Will be ignored if URL contains a
-    query string
+    :param post_params: POST Parameters passed to your URL
     :param auth_token: Plivo Auth token
     :param signature: X-Plivo-Signature header
     :return: True if the request matches signature, False otherwise
     """
-    parsed_uri = urlparse(uri.encode('utf-8'))
-    qs = parsed_uri.query
-    if qs:
+    if post_params:
+        all_params = post_params
+        encoded_request = uri
+    else:
+        parsed_uri = urlparse(uri.encode('utf-8'))
         # get params from query string
-        all_params = dict(parse_qsl(qs, keep_blank_values=True))
+        all_params = dict(parse_qsl(parsed_uri.query, keep_blank_values=True))
         # remove parameters from query string
         encoded_request = urljoin(uri, parsed_uri.path).encode('utf-8')
-    else:
-        all_params = post_params or {}
-        encoded_request = uri.encode('utf-8')
+
     for k, v in sorted(all_params.items()):
         encoded_key = k.encode('utf-8')
         if isinstance(v, unicode):

--- a/tests.py
+++ b/tests.py
@@ -1649,6 +1649,16 @@ class TestValidateRequestSignature(unittest.TestCase):
         is_valid = plivo.validate_signature(uri, params, expected_signature, 'ODE1ZmJkNzI3MzIwMmNmMDBiMDFiNjkxMDhlMjZj')
         self.assertTrue(is_valid)
 
+    # POST on uri with querystring
+    def test_querystring_on_post(self):
+        uri = 'http://requestb.in/1gzeupi1?foo=bar'
+        form_data = 'Direction=inbound&From=Anonymous&CallerName=Anonymous&BillRate=0.0085&To=14154830338&' \
+                    'CallUUID=69ffdb0d-27b6-424e-8e85-e733ddbd9e6a&CallStatus=ringing&Event=StartApp'
+        expected_signature = 'BcdCaUVUvoygI7N0ZFT5MPcQv8o='
+        params = dict(urlparse.parse_qsl(form_data, keep_blank_values=True))
+        is_valid = plivo.validate_signature(uri, params, expected_signature, self.test_auth_token)
+        self.assertTrue(is_valid)
+
 
 def get_client(AUTH_ID, AUTH_TOKEN):
     return plivo.RestAPI(AUTH_ID, AUTH_TOKEN)


### PR DESCRIPTION
When doing a POST on a URL with query strings, the POST data is used for computing the signature, and not the query string parameters.