### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ python:
     - "3.5-dev" # 3.5 development branch
     - "3.6"
     - "3.6-dev" # 3.6 development branch
+    - "3.7"
+    - "3.7-dev" # 3.7 development branch
 install: pip install tox-travis
 script: tox

--- a/plivo/xml/DTMFElement.py
+++ b/plivo/xml/DTMFElement.py
@@ -8,30 +8,30 @@ class DTMFElement(PlivoXMLElement):
     _nestable = []
 
     @property
-    def async(self):
+    def async_(self):
         return self.__async
 
-    @async.setter
-    def async(self, value):
+    @async_.setter
+    def async_(self, value):
         self.__async = bool(value) if value is not None else None
 
     def set_async(self, value):
-        self.async = value
+        self.async_ = value
         return self
 
     def __init__(
             self,
             content,
-            async=None,
+            async_=None,
     ):
         super(DTMFElement, self).__init__()
 
         self.content = content
-        self.async = async
+        self.async_ = async_
 
     def to_dict(self):
         d = {
-            'async': self.async,
+            'async': self.async_,
         }
         return {
             k: six.text_type(map_type(v))

--- a/plivo/xml/ResponseElement.py
+++ b/plivo/xml/ResponseElement.py
@@ -135,11 +135,11 @@ class ResponseElement(PlivoXMLElement):
     def add_dtmf(
             self,
             content,
-            async=None,
+            async_=None,
     ):
         self.add(DTMFElement(
             content=content,
-            async=async,
+            async_=async_,
         ))
         return self
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'requests >= 2, < 3',
         'six >= 1, < 2',
         'decorator >= 4, < 5',
-        'lxml >= 3, < 4',
+        'lxml >= 3, < 5',
     ],
     keywords=['plivo', 'plivo xml', 'voice calls', 'sms'],
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,8 @@
 
 [tox]
 envlist =
-    py27
-    py33
-    py34
-    py35
-    py36
-    py37
-    pypy
+    py{27,33,34,35,36,py}-lxml{3,4}
+    py37-lxml4
 
 [testenv]
 commands = nosetests --with-coverage --cover-package=plivo --cover-html
@@ -25,7 +20,8 @@ deps =
     nose
     httmock
     six
-    lxml
+    lxml3: lxml>=3,<4
+    lxml4: lxml>=4,<5
 
 setenv =
     PYTHONPATH = {toxinidir}/

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     py34
     py35
     py36
+    py37
     pypy
 
 [testenv]


### PR DESCRIPTION
We're slightly bleeding edge and target Python 3.7, which has two primary constraints when it comes to using this library, which this pull request addresses:

1. The `async` keyword is now reserved, so I've taken the liberty of refactoring references to `async_` like a number of other libraries have. I know that this is a breaking change, but it would be necessary for anyone planning to follow the Python 3 version chain.
2. lxml 3.x does not compile under Python 3.7. However, it turns out that this library (at least judging from the test suite) is fully compatible with lxml 4.x, so expanding the supported library range should be safe. I've extended the test matrix under tox to test <3.7 against both lxml 3 and 4 so that we are certain that for people locked into version 3 for other reasons, no issues are introduced.

Let me know your thoughts!