### PR TITLE
added circleci config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:2.7
+      - image: circleci/python:3.4
+      - image: circleci/python:3.5
+      - image: circleci/python:3.6
+      - image: circleci/python:3.7
+      - image: circleci/python:3.7-dev
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            pip install coverage nose httmock six lxml
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            nosetests --with-coverage --cover-package=plivo --cover-html
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports


### PR DESCRIPTION
### Problem:

Circle CI build is failing

```
py34 create: /home/ubuntu/plivo-python/.tox/py34
ERROR: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for python3.4: pyenv: python3.4: command not found\n\nThe `python3.4' command exists in these Python versions:\n  3.4.3\n  3.4.4\n\n", None)
py35 create: /home/ubuntu/plivo-python/.tox/py35
ERROR: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for python3.5: pyenv: python3.5: command not found\n\nThe `python3.5' command exists in these Python versions:\n  3.5.1\n  3.5.2\n  3.5.3\n\n", None)
py36 create: /home/ubuntu/plivo-python/.tox/py36
ERROR: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for python3.6: pyenv: python3.6: command not found\n\nThe `python3.6' command exists in these Python versions:\n  3.6.1\n  3.6.2\n\n", None)
py37 create: /home/ubuntu/plivo-python/.tox/py37
ERROR: InterpreterNotFound: python3.7
pypy create: /home/ubuntu/plivo-python/.tox/pypy
ERROR: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for pypy: pyenv: pypy: command not found\n\nThe `pypy' command exists in these Python versions:\n  pypy-1.9\n  pypy-2.6.1\n  pypy-4.0.1\n\n", None)
___________________________________ summary ____________________________________
  py27: commands succeeded
ERROR:   py34: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for python3.4: pyenv: python3.4: command not found\n\nThe `python3.4' command exists in these Python versions:\n  3.4.3\n  3.4.4\n\n", None)
ERROR:   py35: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for python3.5: pyenv: python3.5: command not found\n\nThe `python3.5' command exists in these Python versions:\n  3.5.1\n  3.5.2\n  3.5.3\n\n", None)
ERROR:   py36: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for python3.6: pyenv: python3.6: command not found\n\nThe `python3.6' command exists in these Python versions:\n  3.6.1\n  3.6.2\n\n", None)
ERROR:  py37: InterpreterNotFound: python3.7
ERROR:   pypy: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError("Failed to get version_info for pypy: pyenv: pypy: command not found\n\nThe `pypy' command exists in these Python versions:\n  pypy-1.9\n  pypy-2.6.1\n  pypy-4.0.1\n\n", None)
```

### Solution:
Added configuration file for **CircleCI**