### PR TITLE
Removed the unsupported Python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
       - image: circleci/python:3.5
       - image: circleci/python:3.6
       - image: circleci/python:3.7
-      - image: circleci/python:3.7-dev
 
     working_directory: ~/repo
 
@@ -30,6 +29,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            sudo apt-get install python3-venv
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt


### PR DESCRIPTION
### Problem
CircleCI doesn't support Python version 3.7-dev 

### Solution
Removed the Unsupported python version
