### PR TITLE
beta-4.2.0b1 | fixed ImportError: cannot import name Phlos

### DIFF
--- a/plivo/resources/__init__.py
+++ b/plivo/resources/__init__.py
@@ -6,6 +6,7 @@ from .conferences import Conferences
 from .endpoints import Endpoints
 from .messages import Messages
 from .numbers import Numbers
+from .phlos import Phlos
 from .pricings import Pricings
 from .recordings import Recordings
 from .addresses import Addresses


### PR DESCRIPTION
### Problem
A user reported import error while invoking PHLO client on beta-4.2.0b1 release
```
In [1]: import plivo
   ...: 
   ...: authid = 'SECRET'
   ...: authtoken = 'SECRET'
   ...: phlo_id = 'your_phlo_id' # https://console.plivo.com/phlo/list/
   ...: phlo_client = plivo.phlo.RestClient(auth_id=authid, auth_token=authtoken)
   ...: phlo = phlo_client.phlo.get(phlo_id)
   ...: response = phlo.run()
   ...: print str(response)
```

Traceback
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-025f08bb6883> in <module>()
----> 1 import plivo
      2 
      3 authid = 'SECRET'
      4 authtoken = 'SECRET'
      5 phlo_id = 'your_phlo_id' # https://console.plivo.com/phlo/list/

/home/vaibhav/workspace/plivo-python/plivo/__init__.py in <module>()
      2 from . import exceptions
      3 from .rest import Client as RestClient
----> 4 from .rest import phlo
      5 from . import xml as plivoxml

/home/vaibhav/workspace/plivo-python/plivo/rest/phlo.py in <module>()
----> 1 from .phlo_client import PhloClient as RestClient

/home/vaibhav/workspace/plivo-python/plivo/rest/phlo_client.py in <module>()
      3 Phlo client, used for Phlo API requests.
      4 """
----> 5 from plivo.resources import Phlos
      6 from plivo.rest.base_client import BaseClient
      7 from requests import Request

ImportError: cannot import name Phlos
```

### Solution
Added missing package import lost on merge.

### Testing
```
$ nosetests tests/
...........................................................................................................................................
----------------------------------------------------------------------
Ran 139 tests in 0.185s

OK
```