### PR TITLE
powerpack: Fix unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [4.8.1](https://github.com/plivo/plivo-python/tree/v4.8.1) (2020-06-12)
+- Fix SMS Test cases.
+
 ## [4.8.0](https://github.com/plivo/plivo-python/tree/v4.8.0) (2020-05-28)
 - Add JWT helper functions.
 

--- a/plivo/resources/numberpools.py
+++ b/plivo/resources/numberpools.py
@@ -18,7 +18,7 @@ class NumberPool(PlivoResource):
     
     
 class Numbers(PlivoResource):
-    _name = 'Shortcodes'
+    _name = 'Numbers'
     _identifier_string = 'number_pool_id'
 
     def buy_add_number(self,
@@ -240,4 +240,4 @@ class Tollfree(PlivoResource):
             'DELETE', ('NumberPool',self.number_pool_id,'Tollfree', tollfree), params,
             response_type=None,
             objects_type=None)
-    
+

--- a/plivo/version.py
+++ b/plivo/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '4.8.0'
+__version__ = '4.8.1'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ See https://github.com/plivo/plivo-python for more information.
 
 setup(
     name='plivo',
-    version='4.8.0',
+    version='4.8.1',
     description='A Python SDK to make voice calls & send SMS using Plivo and to generate Plivo XML',
     long_description=long_description,
     url='https://github.com/plivo/plivo-python',

--- a/tests/resources/fixtures/powerpackAddNumberResponse.json
+++ b/tests/resources/fixtures/powerpackAddNumberResponse.json
@@ -1,0 +1,11 @@
+{
+    "account_phone_number_resource": "/v1/Account/<auth_id>/Number/<your_number>/",
+    "added_on": "2019-10-09T11:24:35.085797Z",
+    "api_id": "612982e8-0a87-11ea-b072-0242ac110007",
+    "country_iso2": "CA",
+    "number": "15799140336",
+    "uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool_uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool": "/v1/Account/MAODZKMDFJMJU3MTEYNG/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/",
+    "type": "fixed"
+}

--- a/tests/resources/fixtures/powerpackAddTollfreeResponse.json
+++ b/tests/resources/fixtures/powerpackAddTollfreeResponse.json
@@ -1,0 +1,11 @@
+{
+    "account_phone_number_resource": "/v1/Account/<auth_id>/Number/<your_number>/",
+    "added_on": "2019-10-09T11:24:35.085797Z",
+    "api_id": "612982e8-0a87-11ea-b072-0242ac110007",
+    "country_iso2": "CA",
+    "number": "15799140336",
+    "uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool_uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool": "/v1/Account/MAODZKMDFJMJU3MTEYNG/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/",
+    "type": "fixed"
+}

--- a/tests/resources/fixtures/powerpackBuyAndNumberResponse.json
+++ b/tests/resources/fixtures/powerpackBuyAndNumberResponse.json
@@ -1,0 +1,11 @@
+{
+    "account_phone_number_resource": "/v1/Account/<auth_id>/Number/<your_number>/",
+    "added_on": "2019-10-09T11:24:35.085797Z",
+    "api_id": "612982e8-0a87-11ea-b072-0242ac110007",
+    "country_iso2": "CA",
+    "number": "14845071864",
+    "uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool_uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool": "/v1/Account/MAODZKMDFJMJU3MTEYNG/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/",
+    "type": "fixed"
+}

--- a/tests/resources/fixtures/powerpackCountNumbersResponse.json
+++ b/tests/resources/fixtures/powerpackCountNumbersResponse.json
@@ -1,0 +1,43 @@
+{
+    "account_phone_number_resource": "/v1/Account/<auth_id>/Number/<your_number>/",
+    "added_on": "2019-10-09T11:24:35.085797Z",
+    "api_id": "612982e8-0a87-11ea-b072-0242ac110007",
+    "country_iso2": "CA",
+    "uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool_uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool": "/v1/Account/MAODZKMDFJMJU3MTEYNG/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/",
+    "api_id": "0dacbefa-0a87-11ea-b072-0242ac110007",
+    "meta": {
+        "limit": 20,
+        "next": "",
+        "offset": 0,
+        "previous": "",
+        "total_count": 6
+    },
+    "objects": [
+        {
+            "account_phone_number_resource": "/v1/Account/{auth_id}/Number/{your_number}/",
+            "added_on": "2019-10-09T11:24:35.085797Z",
+            "country_iso2": "US",
+            "number": "{your_number}",
+            "number_pool_uuid": "{number_pool_uuid}",
+            "type": "fixed"
+        },
+        {
+            "account_phone_number_resource": "/v1/Account/{auth_id}/Number/{your_number}/",
+            "added_on": "2019-10-09T11:24:35.085797Z",
+            "country_iso2": "US",
+            "number": "{your_number}",
+            "number_pool_uuid": "{number_pool_uuid}",
+            "type": "fixed"
+        },
+        {
+            "account_phone_number_resource": "/v1/Account/{auth_id}/Number/{your_number}/",
+            "added_on": "2019-10-09T11:24:35.085797Z",
+            "country_iso2": "CA",
+            "number": "{your_number}",
+            "number_pool_uuid": "{number_pool_uuid}",
+            "type": "fixed"
+        }
+    ]
+}

--- a/tests/resources/fixtures/powerpackCreatePowerpackResponse.json
+++ b/tests/resources/fixtures/powerpackCreatePowerpackResponse.json
@@ -1,0 +1,11 @@
+{
+    "api_id": "4b2c83c4-09ff-11ea-b072-0242ac110007",
+    "application_id": "20342783288007824",
+    "application_type": "XML",
+    "created_on": "2019-10-09T11:10:59.666461Z",
+    "local_connect": true,
+    "name": "test",
+    "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+    "sticky_sender": true,
+    "uuid": "<powerpack_uuid>"
+}

--- a/tests/resources/fixtures/powerpackDeletePowerpackResponse.json
+++ b/tests/resources/fixtures/powerpackDeletePowerpackResponse.json
@@ -1,0 +1,10 @@
+{
+  "uuid": "dfsd-fsdfsd-345dfsd-fsdfs-sdfsd",
+  "name": "My Powerpack",
+  "smart_sender": true,
+  "local_connect": false,
+  "application_type": "XML",
+  "application_id": 123912833468,
+  "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+  "created_on": "2019-07-15T12:22:00Z"
+}

--- a/tests/resources/fixtures/powerpackFindShortcodeResponse.json
+++ b/tests/resources/fixtures/powerpackFindShortcodeResponse.json
@@ -1,0 +1,20 @@
+{
+    "api_id": "614b2776-0a88-11ea-b072-0242ac110007",
+    "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+    "uuid": "dfsd-fsdfsd-345dfsd-fsdfs-sdfsd",
+    "meta": {
+        "limit": 20,
+        "next": "",
+        "offset": 0,
+        "previous": "",
+        "total_count": 1
+    },
+    "objects": [
+        {
+            "added_on": "2019-10-09T11:10:59.741978Z",
+            "country_iso2": "US",
+            "number_pool_uuid": "{number_pool_uuid}",
+            "shortcode": "444444"
+        }
+    ]
+}

--- a/tests/resources/fixtures/powerpackFindTollfreeResponse.json
+++ b/tests/resources/fixtures/powerpackFindTollfreeResponse.json
@@ -1,0 +1,20 @@
+{
+    "api_id": "614b2776-0a88-11ea-b072-0242ac110007",
+    "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+    "uuid": "dfsd-fsdfsd-345dfsd-fsdfs-sdfsd",
+    "meta": {
+        "limit": 20,
+        "next": "",
+        "offset": 0,
+        "previous": "",
+        "total_count": 1
+    },
+    "objects": [
+        {
+            "added_on": "2019-10-09T11:10:59.741978Z",
+            "country_iso2": "US",
+            "number_pool_uuid": "{number_pool_uuid}",
+            "tollfree": "18772209942"
+        }
+    ]
+}

--- a/tests/resources/fixtures/powerpackGetPowerpackResponse.json
+++ b/tests/resources/fixtures/powerpackGetPowerpackResponse.json
@@ -1,0 +1,10 @@
+{
+  "uuid": "5ec4c8c9-cd74-42b5-9e41-0d7670d6bb46",
+  "name": "My Powerpack",
+  "smart_sender": true,
+  "local_connect": false,
+  "application_type": "XML",
+  "application_id": 123912833468,
+  "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+  "created_on": "2019-07-15T12:22:00Z"
+}

--- a/tests/resources/fixtures/powerpackListNumbersResponse.json
+++ b/tests/resources/fixtures/powerpackListNumbersResponse.json
@@ -1,0 +1,38 @@
+{
+    "api_id": "0dacbefa-0a87-11ea-b072-0242ac110007",
+    "uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+    "number_pool": "/v1/Account/{auth_id}/NumberPool/d35f2e82-d387-427f-8594-6fa07613c43a/",
+    "meta": {
+        "limit": 20,
+        "next": "",
+        "offset": 0,
+        "previous": "",
+        "total_count": 3
+    },
+    "objects": [
+        {
+            "account_phone_number_resource": "/v1/Account/{auth_id}/Number/{your_number}/",
+            "added_on": "2019-10-09T11:24:35.085797Z",
+            "country_iso2": "US",
+            "number": "{your_number}",
+            "number_pool_uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+            "type": "fixed"
+        },
+        {
+            "account_phone_number_resource": "/v1/Account/{auth_id}/Number/{your_number}/",
+            "added_on": "2019-10-09T11:24:35.085797Z",
+            "country_iso2": "US",
+            "number": "{your_number}",
+            "number_pool_uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+            "type": "fixed"
+        },
+        {
+            "account_phone_number_resource": "/v1/Account/{auth_id}/Number/{your_number}/",
+            "added_on": "2019-10-09T11:24:35.085797Z",
+            "country_iso2": "CA",
+            "number": "{your_number}",
+            "number_pool_uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+            "type": "fixed"
+        }
+    ]
+}

--- a/tests/resources/fixtures/powerpackListPowerpackResponse.json
+++ b/tests/resources/fixtures/powerpackListPowerpackResponse.json
@@ -1,0 +1,41 @@
+{
+    "api_id": "e44c159e-0a02-11ea-b072-0242ac110007",
+    "meta": {
+        "limit": 20,
+        "next": "/api/v1/account/xxxxxxx/Powerpack?offset=20&limit=20",
+        "offset": 0,
+        "total_count": 53
+    },
+    "objects": [
+        {
+            "application_id": "",
+            "application_type": "",
+            "created_on": "2019-10-09T11:10:59.666461Z",
+            "local_connect": true,
+            "name": "test",
+            "number_pool": "/v1/Account/xxxxxxxxx/NumberPool/<number_pool_uuid>/",
+            "sticky_sender": true,
+            "uuid": "<powerpack_uuid>"
+        },
+        {
+            "application_id": "",
+            "application_type": "",
+            "created_on": "2019-10-09T17:03:31.837944Z",
+            "local_connect": false,
+            "name": "p23",
+            "number_pool": "/v1/Account/xxxxxxxx/NumberPool/<number_pool_uuid>/",
+            "sticky_sender": false,
+            "uuid": "<powerpack_uuid>"
+        },
+        {
+            "application_id": "",
+            "application_type": "",
+            "created_on": "2019-10-09T16:54:34.0117Z",
+            "local_connect": false,
+            "name": "p22",
+            "number_pool": "/v1/Account/xxxxxxxx/NumberPool/<number_pool_uuid>/",
+            "sticky_sender": false,
+            "uuid": "<powerpack_uuid>"
+        }
+    ]
+}

--- a/tests/resources/fixtures/powerpackListShortcodeResponse.json
+++ b/tests/resources/fixtures/powerpackListShortcodeResponse.json
@@ -1,0 +1,20 @@
+{
+    "api_id": "614b2776-0a88-11ea-b072-0242ac110007",
+    "uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool": "/v1/Account/xxxxxxxxx/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/",
+    "meta": {
+	"limit": 20,
+	"offset": 0,
+        "next": "",
+        "previous": "",
+        "total_count": 1
+    },
+    "objects": [
+        {
+            "added_on": "2019-10-09T11:10:59.741978Z",
+            "country_iso2": "US",
+            "number_pool_uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+            "shortcode": "{your_shortcode}"
+        }
+    ]
+}

--- a/tests/resources/fixtures/powerpackListTollfreeResponse.json
+++ b/tests/resources/fixtures/powerpackListTollfreeResponse.json
@@ -1,0 +1,20 @@
+{
+    "api_id": "614b2776-0a88-11ea-b072-0242ac110007",
+    "uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+    "number_pool": "/v1/Account/xxxxxxxxx/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/",
+    "meta": {
+	"limit": 20,
+	"offset": 0,
+        "next": "",
+        "previous": "",
+        "total_count": 1
+    },
+    "objects": [
+        {
+            "added_on": "2019-10-09T11:10:59.741978Z",
+            "country_iso2": "US",
+            "number_pool_uuid": "ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f",
+            "tollfree": "{your_tollfree}"
+        }
+    ]
+}

--- a/tests/resources/fixtures/powerpackRemoveNumberResponse.json
+++ b/tests/resources/fixtures/powerpackRemoveNumberResponse.json
@@ -1,0 +1,10 @@
+{
+  "uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+  "name": "My Powerpack",
+  "smart_sender": true,
+  "local_connect": false,
+  "application_type": "XML",
+  "application_id": 123912833468,
+  "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+  "created_on": "2019-07-15T12:22:00Z"
+}

--- a/tests/resources/fixtures/powerpackRemoveShortcodeResponse.json
+++ b/tests/resources/fixtures/powerpackRemoveShortcodeResponse.json
@@ -1,0 +1,10 @@
+{
+  "uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+  "name": "My Powerpack",
+  "smart_sender": true,
+  "local_connect": false,
+  "application_type": "XML",
+  "application_id": 123912833468,
+  "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+  "created_on": "2019-07-15T12:22:00Z"
+}

--- a/tests/resources/fixtures/powerpackRemoveTollfreeResponse.json
+++ b/tests/resources/fixtures/powerpackRemoveTollfreeResponse.json
@@ -1,0 +1,10 @@
+{
+  "uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+  "name": "My Powerpack",
+  "smart_sender": true,
+  "local_connect": false,
+  "application_type": "XML",
+  "application_id": 123912833468,
+  "number_pool": "/v1/Account/{auth_id}/NumberPool/<number_pool_uuid>/",
+  "created_on": "2019-07-15T12:22:00Z"
+}

--- a/tests/resources/fixtures/powerpackUpdatePowerpackResponse.json
+++ b/tests/resources/fixtures/powerpackUpdatePowerpackResponse.json
@@ -1,0 +1,12 @@
+{
+    "api_id": "4b2c83c4-09ff-11ea-b072-0242ac110007",
+    "uuid": "d35f2e82-d387-427f-8594-6fa07613c43a",
+    "application_id": "20342783288007824",
+    "application_type": "XML",
+    "created_on": "2019-10-09T11:10:59.666461Z",
+    "local_connect": true,
+    "name": "test",
+    "number_pool": "/v1/Account/{auth_id}/NumberPool/d35f2e82-d387-427f-8594-6fa07613c43a/",
+    "sticky_sender": true,
+    "uuid": "<powerpack_uuid>"
+}

--- a/tests/resources/test_powerpacks.py
+++ b/tests/resources/test_powerpacks.py
@@ -17,7 +17,7 @@ class PowerpackTest(PlivoResourceTestCase):
         response = self.client.powerpacks.get(uuid='5ec4c8c9-cd74-42b5-9e41-0d7670d6bb46')
         # Verifying the endpoint hit
         self.assertUrlEqual(
-            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/Powerpack/',
+            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/Powerpack/5ec4c8c9-cd74-42b5-9e41-0d7670d6bb46/',
             self.client.current_request.url)
 
         # Verifying the method used
@@ -38,7 +38,7 @@ class PowerpackTest(PlivoResourceTestCase):
     @with_response(200)
     def test_update_powerpack(self):
         params = {}
-        params['name'] = 'test_sdk_ppk'
+        params['name'] = 'test'
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         response= powerpack.update(params)
         self.assertEqual(params['name'], response['name'])
@@ -48,8 +48,6 @@ class PowerpackTest(PlivoResourceTestCase):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         response = powerpack.delete()
         self.assertEqual('DELETE', self.client.current_request.method)
-        self.assertEqual('success', response['response'])
-
 
     @with_response(200)
     def test_list_numbers(self):
@@ -58,16 +56,13 @@ class PowerpackTest(PlivoResourceTestCase):
         #response= powerpack.numberpool.numbers.list( )
         # Test if ListResponseObject's __iter__ is working correctly
         self.assertEqual(len(list(numberpoolnumber)), 3)
-
-        print(self.client.current_request.url)
-
         # Verifying the endpoint hit
         self.assertUrlEqual(
-            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/Number/',
+            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/NumberPool/d35f2e82-d387-427f-8594-6fa07613c43a/Number/',
             self.client.current_request.url)
-
         # Verifying the method used
         self.assertEqual('GET', self.client.current_request.method)
+
     @with_response(200)
     def test_count_numbers(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
@@ -75,11 +70,10 @@ class PowerpackTest(PlivoResourceTestCase):
         count = powerpack.count_numbers()
         self.assertEqual(6, count)
 
-
     @with_response(200)
     def test_add_number(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
-        response = powerpack.add_number( number='15799140336')
+        response = powerpack.add_number(number='15799140336')
         #response= powerpack.numberpool.numbers.add( number='15799140336')
         self.assertEqual('POST', self.client.current_request.method)
         self.assertUrlEqual(
@@ -89,7 +83,7 @@ class PowerpackTest(PlivoResourceTestCase):
     @with_response(200)
     def test_add_tollfree(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
-        response = powerpack.add_number( tollfree='18772209942')
+        response = powerpack.add_tollfree(tollfree='18772209942')
         #response= powerpack.numberpool.numbers.add( number='18772209942')
         self.assertEqual('POST', self.client.current_request.method)
         self.assertUrlEqual(
@@ -101,21 +95,21 @@ class PowerpackTest(PlivoResourceTestCase):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         response= powerpack.remove_number( number='15799140336')
         #response= powerpack.numberpool.numbers.remove( number='15799140336')
-        self.assertEqual(200, self.client.current_request.status_code)
+        self.assertEqual('DELETE', self.client.current_request.method)
 
     @with_response(200)
     def test_remove_tollfree(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         response= powerpack.remove_tollfree( tollfree='18772209942')
         #response= powerpack.numberpool.tollfree.remove( number='18772209942')
-        self.assertEqual(200, self.client.current_request.status_code)
+        self.assertEqual('DELETE', self.client.current_request.method)
 
     @with_response(200)
     def test_remove_shortcode(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         response= powerpack.remove_shortcode( shortcode='333333')
         #response= powerpack.numberpool.shortcode.remove( number='333333')
-        self.assertEqual(200, self.client.current_request.status_code)
+        self.assertEqual('DELETE', self.client.current_request.method)
 
     @with_response(200)
     def test_list_shortcode(self):
@@ -123,13 +117,11 @@ class PowerpackTest(PlivoResourceTestCase):
         shortcodes = powerpack.list_shortcodes()
        # shortcodes = powerpack.numberpool.shortcodes.list()
         # Test if ListResponseObject's __iter__ is working correctly
-        self.assertEqual(len(list(shortcodes)), 3)
-
-        print(self.client.current_request.url)
+        self.assertEqual(len(list(shortcodes)), 1)
 
         # Verifying the endpoint hit
         self.assertUrlEqual(
-            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/Shortcode/',
+            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/Shortcode/?limit=20&offset=0',
             self.client.current_request.url)
 
         # Verifying the method used
@@ -147,7 +139,7 @@ class PowerpackTest(PlivoResourceTestCase):
 
         # Verifying the endpoint hit
         self.assertUrlEqual(
-            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/Tollfree/',
+            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/NumberPool/ca5fd1f2-26c0-43e9-a7e4-0dc426e9dd2f/Tollfree/?limit=20&offset=0',
             self.client.current_request.url)
 
         # Verifying the method used
@@ -156,21 +148,21 @@ class PowerpackTest(PlivoResourceTestCase):
     def test_find_shortcode(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         # response = powerpack.numberpool.shortcodes.find( shortcode='444444')
-        response = powerpack.find_shortcode( shortcode='444444')
-        self.assertEqual('444444', response['shortcode'])
+        response = powerpack.find_shortcode(shortcode='444444')
+        self.assertEqual('444444', response['objects'][0]['shortcode'])
 
     @with_response(200)
     def test_find_tollfree(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         # response = powerpack.numberpool.shortcodes.find( shortcode='444444')
-        response = powerpack.find_shortcode( shortcode='18772209942')
-        self.assertEqual('18772209942', response['shortcode'])
+        response = powerpack.find_tollfree(tollfree='18772209942')
+        self.assertEqual('18772209942', response['objects'][0]['tollfree'])
 
     @with_response(200)
     def test_buy_and_number(self):
         powerpack = self.client.powerpacks.get(uuid='d35f2e82-d387-427f-8594-6fa07613c43a')
         # response = powerpack.numberpool.numbers.buy_add_number( number='14845071864')
-        response = powerpack.buy_add_number( number='14845071864')
+        response = powerpack.buy_add_number(number='14845071864')
         self.assertEqual('POST', self.client.current_request.method)
         self.assertEqual('14845071864', response['number'])
 


### PR DESCRIPTION
Output from a local run:

```sh
prashanthpai@localhost: plivo-python (ppai-ppk-tests *) $ tox -e py36 -- tests/resources/test_powerpacks.py
GLOB sdist-make: /Users/prashanthpai/src/plivo-python/setup.py
py36 inst-nodeps: /Users/prashanthpai/src/plivo-python/.tox/.tmp/package/1/plivo-4.8.0.zip
py36 installed: certifi==2020.4.5.1,chardet==3.0.4,coverage==5.1,decorator==4.4.2,httmock==1.3.0,idna==2.9,lxml==4.5.1,nose==1.3.7,plivo==4.8.0,requests==2.23.0,six==1.15.0,urllib3==1.25.9
py36 run-test-pre: PYTHONHASHSEED='2913172188'
py36 run-test: commands[0] | nosetests -v --with-coverage --cover-package=plivo --cover-html tests/resources/test_powerpacks.py
test_add_number (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_add_tollfree (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_buy_and_number (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_count_numbers (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_create_powerpack (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_delete_powerpack (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_find_shortcode (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_find_tollfree (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_get_powerpack (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_list_numbers (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_list_powerpack (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_list_shortcode (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_list_tollfree (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_remove_number (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_remove_shortcode (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_remove_tollfree (tests.resources.test_powerpacks.PowerpackTest) ... ok
test_update_powerpack (tests.resources.test_powerpacks.PowerpackTest) ... ok

Name                               Stmts   Miss  Cover
------------------------------------------------------
plivo/__init__.py                      4      0   100%
plivo/base.py                        122     69    43%
plivo/exceptions.py                   14      0   100%
plivo/resources/__init__.py           15      0   100%
plivo/resources/accounts.py           45      3    93%
plivo/resources/addresses.py          47     16    66%
plivo/resources/applications.py       43      4    91%
plivo/resources/call_feedback.py      20     14    30%
plivo/resources/calls.py              99     23    77%
plivo/resources/conferences.py        75     13    83%
plivo/resources/endpoints.py          28      4    86%
plivo/resources/identities.py         43     14    67%
plivo/resources/live_calls.py         17      4    76%
plivo/resources/media.py              30     16    47%
plivo/resources/messages.py           31      5    84%
plivo/resources/nodes.py              43     13    70%
plivo/resources/numberpools.py       109     68    38%
plivo/resources/numbers.py            32      2    94%
plivo/resources/phlos.py              47     20    57%
plivo/resources/powerpacks.py        167     44    74%
plivo/resources/pricings.py           13      1    92%
plivo/resources/queued_calls.py       13      2    85%
plivo/resources/recordings.py         32      2    94%
plivo/rest/__init__.py                 1      0   100%
plivo/rest/base_client.py            105     42    60%
plivo/rest/client.py                 148     43    71%
plivo/rest/phlo.py                     1      0   100%
plivo/rest/phlo_client.py             15      0   100%
plivo/utils/__init__.py               37      5    86%
plivo/utils/signature_v3.py           74     57    23%
plivo/utils/validators.py            126      9    93%
plivo/version.py                       1      0   100%
plivo/xml/ConferenceElement.py       211      0   100%
plivo/xml/DTMFElement.py              19      2    89%
plivo/xml/DialElement.py             144     36    75%
plivo/xml/PlivoXMLElement.py          30      3    90%
plivo/xml/ResponseElement.py          45      2    96%
plivo/xml/__init__.py                 29      0   100%
plivo/xml/breakElement.py             27      0   100%
plivo/xml/contElement.py              53     31    42%
plivo/xml/emphasisElement.py          50      0   100%
plivo/xml/getDigitsElement.py        115      2    98%
plivo/xml/getInputElement.py         147      4    97%
plivo/xml/hangupElement.py            26      0   100%
plivo/xml/langElement.py              57      0   100%
plivo/xml/messageElement.py           51      0   100%
plivo/xml/numberElement.py            35      0   100%
plivo/xml/pElement.py                 44      0   100%
plivo/xml/phonemeElement.py           27      0   100%
plivo/xml/playElement.py              19      0   100%
plivo/xml/preAnswerElement.py         31      0   100%
plivo/xml/prosodyElement.py           69      0   100%
plivo/xml/recordElement.py           130      0   100%
plivo/xml/redirectElement.py          20      0   100%
plivo/xml/sElement.py                 38      0   100%
plivo/xml/sayAsElement.py             27      0   100%
plivo/xml/speakElement.py             76      0   100%
plivo/xml/subElement.py               19      0   100%
plivo/xml/userElement.py              35      0   100%
plivo/xml/wElement.py                 37      0   100%
plivo/xml/waitElement.py              42      0   100%
plivo/xml/xmlUtils.py                  5      0   100%
------------------------------------------------------
TOTAL                               3255    573    82%
----------------------------------------------------------------------
Ran 17 tests in 0.053s

OK
_________________________________________________________________________________________________ summary __________________________________________________________________________________________________
  py36: commands succeeded
  congratulations :)
```