### PR TITLE
run tests on Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -11,7 +11,7 @@ jobs:
     name: UnitTests
     strategy:
       matrix:
-        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11 ]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
@@ -36,7 +36,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python-version: [3.9]
+          python-version: [3.11]
       steps:  
         - uses: actions/checkout@v2
         - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Communications :: Telephony',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ envlist =
     py37
     py38
     py39
+    py310
+    py311
     pypy
 
 [testenv]


### PR DESCRIPTION
This change starts to run CI tests on Python 3.10 and Python 3.11.
There is also a configuration for CircleCI but it looks like this hasn't been used for a very long time so I did not touch it.

Note: Tests on Python 3.11 won't pass without this change: https://github.com/plivo/plivo-python/pull/221

Question: Why are tests running on MacOS?