### PR TITLE
decode fix for python 2.7 and python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [4.33.1](https://github.com/plivo/plivo-python/tree/v4.33.1) (2023-04-19)
+- Fix decode issue for python 2.x and python 3.x
+
 ## [4.33.0](https://github.com/plivo/plivo-python/tree/v4.33.0) (2023-02-23)
 **Feature - Enhance MDR filtering capabilities **
 - Added new fields on MDR object response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [4.33.1](https://github.com/plivo/plivo-python/tree/v4.33.1) (2023-04-19)
+## [4.33.1](https://github.com/plivo/plivo-python/tree/v4.33.1) (2023-04-20)
 - Fix decode issue for python 2.x and python 3.x
 
 ## [4.33.0](https://github.com/plivo/plivo-python/tree/v4.33.0) (2023-02-23)

--- a/plivo/version.py
+++ b/plivo/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '4.33.0'
+__version__ = '4.33.1'

--- a/plivo/xml/PlivoXMLElement.py
+++ b/plivo/xml/PlivoXMLElement.py
@@ -1,5 +1,5 @@
 from lxml import etree
-
+import six
 from plivo.exceptions import PlivoXMLError
 
 
@@ -36,7 +36,12 @@ class PlivoXMLElement(object):
                 self._name, **self.to_dict())
         if self.content:
             try:
-                e.text = self.content.decode()
+                if six.PY2 and isinstance(self.content, str):
+                    e.text = self.content.decode()
+                elif six.PY3 and isinstance(self.content, bytes):
+                    e.text = self.content.decode()
+                else:
+                    e.text = self.content
             except:
                 e.text = self.content
         for child in self.children:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ See https://github.com/plivo/plivo-python for more information.
 
 setup(
     name='plivo',
-    version='4.33.0',
+    version='4.33.1',
     description='A Python SDK to make voice calls & send SMS using Plivo and to generate Plivo XML',
     long_description=long_description,
     url='https://github.com/plivo/plivo-python',


### PR DESCRIPTION
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/plivo/xml/PlivoXMLElement.py", line 39, in _to_element
    e.text = self.content.decode()
AttributeError: '__proxy__' object has no attribute 'decode'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/django/core/handlers/exception.py", line 42, in inner
    response = get_response(request)
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/share/newfies/plivo_cloud/views.py", line 727, in app_answer_handler
    return HttpResponse(xml_response.to_string(), content_type='application/xml')
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/plivo/xml/PlivoXMLElement.py", line 26, in to_string
    s = self.continue_speak(etree.tostring(self._to_element(), pretty_print=pretty, encoding='unicode'))
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/plivo/xml/PlivoXMLElement.py", line 43, in _to_element
    child._to_element(parent=e)
  File "/usr/share/virtualenvs/max/lib/python3.5/site-packages/plivo/xml/PlivoXMLElement.py", line 41, in _to_element
    e.text = self.content
  File "src/lxml/etree.pyx", line 1042, in lxml.etree._Element.text.__set__
  File "src/lxml/apihelpers.pxi", line 748, in lxml.etree._setNodeText
  File "src/lxml/apihelpers.pxi", line 736, in lxml.etree._createTextNode
  File "src/lxml/apihelpers.pxi", line 1539, in lxml.etree._utf8
TypeError: Argument must be bytes or unicode, got '__proxy__' 