### PR TITLE
Add messages.create (POST /v1/Account/{auth_id}/Message/)

### DIFF
--- a/examples/messages_create.py
+++ b/examples/messages_create.py
@@ -1,0 +1,15 @@
+# Example of sending a message using Plivo API with AllowDTMF option
+# Note: Replace 'your_auth_id' and 'your_auth_token' with your actual Plivo auth credentials
+
+from plivo import RestClient
+
+client = RestClient('your_auth_id', 'your_auth_token')
+
+response = client.messages.create(
+    src='1415XXXXXXX',  # The phone number sending the message
+    dst='1415XXXXXXX',  # The phone number receiving the message
+    text='Hello, this is a test message',  # Your SMS message
+    allow_dtmf=True  # Optional parameter to allow DTMF
+)
+
+print(response)

--- a/plivo/resources/messages.py
+++ b/plivo/resources/messages.py
@@ -46,7 +46,8 @@ class Messages(PlivoResourceInterface):
         location=[optional(is_location())],
         dlt_entity_id=[optional(of_type(six.text_type))],
         dlt_template_id=[optional(of_type(six.text_type))],
-        dlt_template_category=[optional(of_type(six.text_type))]
+        dlt_template_category=[optional(of_type(six.text_type))],
+        allow_dtmf=[optional(of_type_exact(bool))]
     )
     def create(self,
                dst,
@@ -60,13 +61,14 @@ class Messages(PlivoResourceInterface):
                powerpack_uuid=None,
                media_urls=None,
                media_ids=None,
-               message_expiry=None, 
+               message_expiry=None,
                template=None,
                interactive=None,
                location=None,
                dlt_entity_id=None,
                dlt_template_id=None,
-               dlt_template_category=None):
+               dlt_template_category=None,
+               allow_dtmf=None):
         if src in dst.split('<'):
             raise ValidationError(
                 'destination number cannot be same as source number')
@@ -87,7 +89,7 @@ class Messages(PlivoResourceInterface):
                 'src parameter not present'
             )
         if template is not None:
-            template =  template.__dict__
+            template = template.__dict__
         if interactive is not None:
             interactive = interactive.__dict__
         if location is not None:

--- a/tests/resources/test_messages.py
+++ b/tests/resources/test_messages.py
@@ -20,6 +20,21 @@ class MessageTest(PlivoResourceTestCase):
         self.assertEqual(test_message.message_uuid,
                          expected_response['message_uuid'])
 
+    def test_send_message_with_allow_dtmf(self):
+        expected_response = {'message_uuid': 'adsdafkjadshf123123'}
+        self.client.set_expected_response(
+            status_code=202, data_to_return=expected_response)
+
+        test_message = self.client.messages.create(
+            src='1234', dst='12345', text='Abcd', allow_dtmf=True)
+
+        self.assertEqual(
+            self.client.current_request.url,
+            'https://api.plivo.com/v1/Account/MAXXXXXXXXXXXXXXXXXX/Message/')
+        self.assertEqual(self.client.current_request.method, 'POST')
+        self.assertEqual(test_message.message_uuid,
+                         expected_response['message_uuid'])
+
     def test_send_message_same_src_dst(self):
         self.assertRaises(
             exceptions.ValidationError,


### PR DESCRIPTION
# Add messages.create (POST /v1/Account/{auth_id}/Message/)

Base: master ← rune/pr-623-messages-create

Reviewers (picked by recent commit activity):
- narayana-plivo <narayana@plivo.com> (10 commits)
- Kaushik Das <kaushik.das@plivo.com> (6 commits)

Adds messages.create for POST `/v1/Account/{auth_id}/Message/`.

Adds optional AllowDTMF field to message creation request.

**Severity:** minor
**Source:** plivo/api-messaging#623

This PR was drafted by [Rune](https://github.com/plivo/narayana-rune-engine), an
auto-propagation engine that mirrors public-API changes into the SDKs.
Please review the generated code, tests, and example; Rune will not merge.
