### PR TITLE
feat: add number_of_employees field to Profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [4.60.3](https://github.com/plivo/plivo-python/tree/v4.60.3) (2026-06-10)
+**Feature - Profile API number of employees field support**
+- Added Number of Employees field support to Profile API
+
 ## [4.60.2](https://github.com/plivo/plivo-python/tree/v4.60.2) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/plivo/resources/profile.py
+++ b/plivo/resources/profile.py
@@ -61,7 +61,11 @@ class Profile(PlivoResourceInterface):
         address=[optional(of_type_exact(dict))],
         authorized_contact=[optional(of_type_exact(dict))],
         business_contact_email=[optional(of_type(six.text_type))],
-        doing_business_as=[optional(of_type(six.text_type))])
+        doing_business_as=[optional(of_type(six.text_type))],
+        # Optional string. Server validates allowed values; no client-side enum check.
+        # Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200,
+        # BETWEEN_201_AND_500, BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
+        number_of_employees=[optional(of_type(six.text_type))])
     def create(self,
                profile_alias,
                customer_type,
@@ -79,13 +83,14 @@ class Profile(PlivoResourceInterface):
                address={},
                authorized_contact={},
                business_contact_email='',
-               doing_business_as=''):
+               doing_business_as='',
+               number_of_employees=''):
         return self.client.request('POST', ('Profile', ),
                                    to_param_dict(self.create, locals()))
 
 
     # params values should be dictionary like
-    # {'address': {}, 'authorized_contact': {}, 'entity_type':'', 'vertical': '', 'company_name': '', 'website':'', 'business_contact_email':'', 'doing_business_as':''}
+    # {'address': {}, 'authorized_contact': {}, 'entity_type':'', 'vertical': '', 'company_name': '', 'website':'', 'business_contact_email':'', 'doing_business_as':'', 'number_of_employees':''}
     def update(self,profile_uuid, params=None):
         if params == None:
             raise ValidationError(

--- a/plivo/version.py
+++ b/plivo/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '4.60.2'
+__version__ = '4.60.3'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ See https://github.com/plivo/plivo-python for more information.
 
 setup(
     name='plivo',
-    version='4.60.2',
+    version='4.60.3',
     description='A Python SDK to make voice calls & send SMS using Plivo and to generate Plivo XML',
     long_description=long_description,
     url='https://github.com/plivo/plivo-python',

--- a/tests/resources/fixtures/profileGetResponse.json
+++ b/tests/resources/fixtures/profileGetResponse.json
@@ -8,6 +8,7 @@
         "company_name": "ABC Inc.",
         "customer_type": "RESELLER",
         "doing_business_as": "ABC DBA",
+        "number_of_employees": "BETWEEN_1_AND_10",
         "ein": "111111111",
         "ein_issuing_country": "US",
         "entity_type": "PUBLIC_PROFIT",

--- a/tests/resources/test_profile.py
+++ b/tests/resources/test_profile.py
@@ -35,7 +35,8 @@ class ProfileTest(PlivoResourceTestCase):
                     "seniority": "C_LEVEL"
                 },
                 business_contact_email="employee@company.com",
-                doing_business_as="Test DBA"
+                doing_business_as="Test DBA",
+                number_of_employees="BETWEEN_1_AND_10"
         )
         self.assertEqual('POST', self.client.current_request.method)
         self.assertUrlEqual(
@@ -74,7 +75,7 @@ class ProfileTest(PlivoResourceTestCase):
 
     @with_response(200)
     def test_update(self):
-        param = {'company_name': 'google', 'doing_business_as': 'Updated DBA'}
+        param = {'company_name': 'google', 'doing_business_as': 'Updated DBA', 'number_of_employees': 'BETWEEN_11_AND_50'}
         response = self.client.profile.update(profile_uuid='09322f43-fe16-4525-b8e4-4229c867795d', params=param)
         # Verifying the endpoint hit
         print(self.client.current_request.url)


### PR DESCRIPTION
## Description

Adds a new optional `number_of_employees` string field to the Profile (10DLC/A2P account profile) `create` API, and documents it in the `update` params comment. This mirrors the recently shipped `doing_business_as` field and matches a corresponding backend change in campaign-service.

There is no client-side enum validation — any string is accepted and the server validates the value (same handling as `doing_business_as` and `business_contact_email`).

### Allowed values (server-validated, documented in a code comment)
- `BETWEEN_1_AND_10`
- `BETWEEN_11_AND_50`
- `BETWEEN_51_AND_200`
- `BETWEEN_201_AND_500`
- `BETWEEN_501_AND_2000`
- `BETWEEN_2001_AND_10000`
- `MORE_THAN_10001`

### Changes
- `plivo/resources/profile.py`: added field to `create` `@validate_args` (optional string) and method signature (default `''`), updated `update` params comment.
- Tests and fixtures updated for parity with `doing_business_as`.
- Version bumped 4.60.2 -> 4.60.3.
- CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)