### PR TITLE
feat: add compliance_application_id param to numbers.buy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [4.61.0](https://github.com/plivo/plivo-python/tree/v4.61.0) (2026-06-11)
+**Feature - PhoneNumber buy compliance application support**
+- Added optional `compliance_application_id` parameter to `numbers.buy()`, sent as the `compliance_application_id` wire param. Lets regulated numbers (e.g. India) be purchased with an approved regulatory compliance application linked at purchase time. Backward-compatible trailing optional argument.
+
 ## [4.60.2](https://github.com/plivo/plivo-python/tree/v4.60.2) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/plivo/resources/numbers.py
+++ b/plivo/resources/numbers.py
@@ -35,8 +35,9 @@ class Numbers(PlivoResourceInterface):
         app_id=[optional(of_type(six.text_type))],
         verification_info=[optional(of_type_exact(dict))],
         cnam_lookup=[optional(of_type(six.text_type))],
-        ha_enable=[optional(of_type(bool))],)
-    def buy(self, number, app_id=None, verification_info=None, cnam_lookup=None, ha_enable=None):
+        ha_enable=[optional(of_type(bool))],
+        compliance_application_id=[optional(of_type(six.text_type))],)
+    def buy(self, number, app_id=None, verification_info=None, cnam_lookup=None, ha_enable=None, compliance_application_id=None):
         return self.client.request('POST', ('PhoneNumber', number),
                                    to_param_dict(self.buy, locals()))
 

--- a/plivo/version.py
+++ b/plivo/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '4.60.2'
+__version__ = '4.61.0'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ See https://github.com/plivo/plivo-python for more information.
 
 setup(
     name='plivo',
-    version='4.60.2',
+    version='4.61.0',
     description='A Python SDK to make voice calls & send SMS using Plivo and to generate Plivo XML',
     long_description=long_description,
     url='https://github.com/plivo/plivo-python',

--- a/tests/resources/test_numbers.py
+++ b/tests/resources/test_numbers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import json
+
 import plivo
 from tests.base import PlivoResourceTestCase
 from tests.decorators import with_response
@@ -88,3 +90,19 @@ class PhoneNumberTest(PlivoResourceTestCase):
         self.assertUrlEqual(self.client.current_request.url,
                             self.get_url('PhoneNumber', number_id))
         self.assertEqual(self.client.current_request.method, 'POST')
+
+    @with_response(202, method_name='create')
+    def test_create_with_compliance_application_id(self):
+        self.client.numbers.buy(
+            number_id,
+            app_id='test',
+            compliance_application_id='compliance123')
+        self.assertUrlEqual(self.client.current_request.url,
+                            self.get_url('PhoneNumber', number_id))
+        self.assertEqual(self.client.current_request.method, 'POST')
+        body = self.client.current_request.body
+        if isinstance(body, bytes):
+            body = body.decode('utf-8')
+        self.assertEqual(
+            json.loads(body).get('compliance_application_id'),
+            'compliance123')


### PR DESCRIPTION
## What
Adds an optional `compliance_application_id` parameter to `numbers.buy()` (the phone-number purchase method). It is forwarded as the `compliance_application_id` wire parameter on the POST request. Also bumps the SDK version to `4.61.0` with a matching CHANGELOG entry and adds test coverage.

## Why
Regulated numbers (e.g. India) require an approved regulatory compliance application to be linked at purchase time. Previously `buy()` only sent `app_id` / `cnam_lookup` / `ha_enable` (and `verification_info`), with no way to associate a compliance application during the buy call.

The new parameter is a trailing optional argument, so the change is fully backward-compatible — existing callers are unaffected.

## Testing
The full `tests/resources/test_numbers.py` suite passes (10/10), including the new `test_create_with_compliance_application_id` which asserts the param is serialized onto the request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)