### PR TITLE
feat(tollfree-verification): add optional terms, privacy, opt-in and help parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [4.62.0](https://github.com/plivo/plivo-python/tree/v4.62.0) (2026-07-27)
+**Feature - Toll-free verification terms, privacy, opt-in and help fields**
+- Added optional `terms_and_conditions_link`, `privacy_policy_link`, `optin_message` and `help_message` parameters to the toll-free verification create and update methods
+
 ## [4.61.0](https://github.com/plivo/plivo-python/tree/v4.61.0) (2026-06-11)
 **Feature - PhoneNumber buy compliance application support**
 - Added optional `compliance_application_id` parameter to `numbers.buy()`, sent as the `compliance_application_id` wire param. Lets regulated numbers (e.g. India) be purchased with an approved regulatory compliance application linked at purchase time. Backward-compatible trailing optional argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-## [4.62.0](https://github.com/plivo/plivo-python/tree/v4.62.0) (2026-07-27)
+## [4.62.0](https://github.com/plivo/plivo-python/tree/v4.62.0) (2026-07-28)
 **Feature - Toll-free verification terms, privacy, opt-in and help fields**
 - Added optional `terms_and_conditions_link`, `privacy_policy_link`, `optin_message` and `help_message` parameters to the toll-free verification create and update methods
 

--- a/plivo/resources/tollfree_verification.py
+++ b/plivo/resources/tollfree_verification.py
@@ -23,13 +23,20 @@ class TollfreeVerification(PlivoResource):
                extra_data=None,
                optin_type=None,
                callback_url=None,
-               callback_method=None):
+               callback_method=None,
+               terms_and_conditions_link=None,
+               privacy_policy_link=None,
+               optin_message=None,
+               help_message=None):
         return self.client.tollfree_verification.update(self.uuid, profile_uuid=profile_uuid, usecase=usecase,
                                                         usecase_summary=usecase_summary, message_sample=message_sample,
                                                         optin_image_url=optin_image_url, volume=volume,
                                                         additional_information=additional_information,
                                                         extra_data=extra_data, optin_type=optin_type,
-                                                        callback_url=callback_url, callback_method=callback_method)
+                                                        callback_url=callback_url, callback_method=callback_method,
+                                                        terms_and_conditions_link=terms_and_conditions_link,
+                                                        privacy_policy_link=privacy_policy_link,
+                                                        optin_message=optin_message, help_message=help_message)
 
 class TollfreeVerifications(PlivoResourceInterface):
     def __init__(self, client):
@@ -48,7 +55,11 @@ class TollfreeVerifications(PlivoResourceInterface):
                extra_data=None,
                optin_type=None,
                callback_url=None,
-               callback_method=None):
+               callback_method=None,
+               terms_and_conditions_link=None,
+               privacy_policy_link=None,
+               optin_message=None,
+               help_message=None):
         return self.client.request(
             'POST', ('TollfreeVerification',), to_param_dict(self.create, locals()))
 
@@ -82,7 +93,11 @@ class TollfreeVerifications(PlivoResourceInterface):
                extra_data=None,
                optin_type=None,
                callback_url=None,
-               callback_method=None):
+               callback_method=None,
+               terms_and_conditions_link=None,
+               privacy_policy_link=None,
+               optin_message=None,
+               help_message=None):
         return self.client.request(
             'POST', ('TollfreeVerification', tollfree_verification_uuid), to_param_dict(self.update, locals()))
 

--- a/plivo/version.py
+++ b/plivo/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '4.61.0'
+__version__ = '4.62.0'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ See https://github.com/plivo/plivo-python for more information.
 
 setup(
     name='plivo',
-    version='4.61.0',
+    version='4.62.0',
     description='A Python SDK to make voice calls & send SMS using Plivo and to generate Plivo XML',
     long_description=long_description,
     url='https://github.com/plivo/plivo-python',

--- a/tests/resources/test_tollfree_verification.py
+++ b/tests/resources/test_tollfree_verification.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import json
+
 import plivo
 from tests.base import PlivoResourceTestCase
 from tests.decorators import with_response
@@ -49,7 +51,11 @@ class TollfreeVerificationTest(PlivoResourceTestCase):
     def test_update(self):
         updated_app = self.client.tollfree_verification.update(
             tollfree_verification_uuid="312b3119-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-            extra_data='Testing the update of extra data in python-SDK')
+            extra_data='Testing the update of extra data in python-SDK',
+            terms_and_conditions_link="https://example.com/terms",
+            privacy_policy_link="https://example.com/privacy",
+            optin_message="Reply YES to opt in",
+            help_message="Reply HELP for help")
 
         # Verifying the endpoint hit
         self.assertEqual(
@@ -58,6 +64,13 @@ class TollfreeVerificationTest(PlivoResourceTestCase):
 
         # Verifying the method used
         self.assertEqual('POST', self.client.current_request.method)
+
+        # Verifying the new optional params are in the request body
+        request_body = json.loads(self.client.current_request.body)
+        self.assertEqual("https://example.com/terms", request_body['terms_and_conditions_link'])
+        self.assertEqual("https://example.com/privacy", request_body['privacy_policy_link'])
+        self.assertEqual("Reply YES to opt in", request_body['optin_message'])
+        self.assertEqual("Reply HELP for help", request_body['help_message'])
 
     def test_delete(self):
         expected_response = {}
@@ -91,6 +104,10 @@ class TollfreeVerificationTest(PlivoResourceTestCase):
             optin_image_url="http://aaa.com",
             additional_information="this is additional_information",
             extra_data="this is extra_data",
+            terms_and_conditions_link="https://example.com/terms",
+            privacy_policy_link="https://example.com/privacy",
+            optin_message="Reply YES to opt in",
+            help_message="Reply HELP for help",
         )
 
         # Verifying the endpoint hit
@@ -100,3 +117,10 @@ class TollfreeVerificationTest(PlivoResourceTestCase):
 
         # Verifying the method used
         self.assertEqual('POST', self.client.current_request.method)
+
+        # Verifying the new optional params are in the request body
+        request_body = json.loads(self.client.current_request.body)
+        self.assertEqual("https://example.com/terms", request_body['terms_and_conditions_link'])
+        self.assertEqual("https://example.com/privacy", request_body['privacy_policy_link'])
+        self.assertEqual("Reply YES to opt in", request_body['optin_message'])
+        self.assertEqual("Reply HELP for help", request_body['help_message'])


### PR DESCRIPTION
## Summary

Adds four new **optional** parameters to the toll-free verification create and update APIs:

| Parameter | Max length |
|---|---|
| `terms_and_conditions_link` | 2000 |
| `privacy_policy_link` | 2000 |
| `optin_message` | 500 |
| `help_message` | 500 |

## Backward compatibility

All four parameters are optional. Existing calls are unaffected — omitting them produces exactly the same request as before.

## Tests

Existing toll-free verification tests are extended to cover the new parameters on both create and update.