### PR TITLE
feat: add internal flag to Endpoint create params (VT-9534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [4.62.1](https://github.com/plivo/plivo-python/tree/v4.62.1) (2026-07-27)
+**Feature - Internal flag support on Endpoint create**
+- Added `internal` optional parameter to Endpoint `create` method to mark newly created SIP endpoints as internal at creation time
+
 ## [4.61.0](https://github.com/plivo/plivo-python/tree/v4.61.0) (2026-06-11)
 **Feature - PhoneNumber buy compliance application support**
 - Added optional `compliance_application_id` parameter to `numbers.buy()`, sent as the `compliance_application_id` wire param. Lets regulated numbers (e.g. India) be purchased with an approved regulatory compliance application linked at purchase time. Backward-compatible trailing optional argument.

--- a/plivo/resources/endpoints.py
+++ b/plivo/resources/endpoints.py
@@ -32,8 +32,9 @@ class Endpoints(PlivoResourceInterface):
         app_id=[optional(of_type(six.text_type))],
         callback_url=[optional(is_url())],
         callback_method=[optional(of_type(six.text_type))],
+        internal=[optional(of_type(bool))],
     )
-    def create(self, username, password, alias, app_id=None, callback_url=None, callback_method=None):
+    def create(self, username, password, alias, app_id=None, callback_url=None, callback_method=None, internal=None):
         return self.client.request('POST', ('Endpoint', ),
                                    to_param_dict(self.create, locals()), is_voice_request=True)
 

--- a/plivo/version.py
+++ b/plivo/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '4.61.0'
+__version__ = '4.62.1'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ See https://github.com/plivo/plivo-python for more information.
 
 setup(
     name='plivo',
-    version='4.61.0',
+    version='4.62.1',
     description='A Python SDK to make voice calls & send SMS using Plivo and to generate Plivo XML',
     long_description=long_description,
     url='https://github.com/plivo/plivo-python',


### PR DESCRIPTION
## Summary
Adds an optional `internal` argument to the Endpoint `create` method so callers can mark newly created SIP endpoints as internal at creation time.

## Why
Plivo CX (Contacto) auto-creates a SIP endpoint per AOM during user invite for browser-SDK playback. These internal endpoints currently leak into the customer's Endpoints tab in the console (Pylon #2460), causing confusion, prod alerts, and a security concern. The trace service already supports an `internal` column on the endpoint model + defaults the List API to exclude internal endpoints. What's missing is the ability for the auto-create call (Hodor) to actually mark endpoints as `internal=true` at creation time. This SDK change unblocks that.

## Change
- `plivo/resources/endpoints.py` — added optional `internal` kwarg to `Endpoints.create`, forwarded to the request body when set (serialized as JSON key `internal`).
- `setup.py`, `plivo/version.py`, `CHANGELOG.md` — patch version bump (4.61.0 -> 4.61.1).

## Backwards-compatibility
When `internal` is unset (default `None`), `to_param_dict` drops it and the wire payload is unchanged. Only callers that explicitly set `internal=True` opt into the new path.

## Test plan
- [x] `python -m py_compile plivo/resources/endpoints.py` clean
- [ ] End-to-end sanity: hit `api.plivo.com` create endpoint with `internal=true` and verify `subscriber.internal = true` on the row (validated separately by the CX team's integration)

## Related
- JIRA: VT-9534
- Companion PR: https://github.com/plivo/plivo-go/pull/250
- Similar PRs opening in parallel across plivo-node, plivo-ruby, plivo-java, plivo-php, plivo-dotnet